### PR TITLE
Mirror of dropbox json11#83

### DIFF
--- a/json11.hpp
+++ b/json11.hpp
@@ -75,6 +75,7 @@ enum JsonParse {
 };
 
 class JsonValue;
+class JsonHandler;
 
 class Json final {
 public:
@@ -188,6 +189,24 @@ public:
         std::string::size_type parser_stop_pos;
         return parse_multi(in, parser_stop_pos, err, strategy);
     }
+    // Parse. If parse fails, return Json() and assign an error message to err.
+    static void parse_event(const std::string & in,
+                            std::string::size_type & parser_stop_pos,
+                            std::string & err,
+                            std::shared_ptr<JsonHandler> handler,
+                            JsonParse strategy = JsonParse::STANDARD);
+    static void parse_event(const char * in,
+                            std::string::size_type & parser_stop_pos,
+                            std::string & err,
+                            std::shared_ptr<JsonHandler> handler,
+                            JsonParse strategy = JsonParse::STANDARD) {
+        if (in) {
+            parse_event(std::string(in), parser_stop_pos, err, handler, strategy);
+        } else {
+            err = "null input";
+            return;
+        }
+    }
 
     bool operator== (const Json &rhs) const;
     bool operator<  (const Json &rhs) const;
@@ -227,6 +246,22 @@ protected:
     virtual const Json::object &object_items() const;
     virtual const Json &operator[](const std::string &key) const;
     virtual ~JsonValue() {}
+};
+
+/* event parsing
+ *
+ * Callbacks called when parsing the json
+ */
+class JsonHandler {
+public:
+    virtual ~JsonHandler() {};
+    virtual void json_object_begin() = 0;
+    virtual void json_object_end() = 0;
+    virtual void json_object_key(const std::string &key) = 0;
+    virtual void json_object_value(const std::string &key, const Json &value) = 0;
+    virtual void json_array_begin() = 0;
+    virtual void json_array_end() = 0;
+    virtual void json_array_value(const Json &value) = 0;
 };
 
 } // namespace json11


### PR DESCRIPTION
Mirror of dropbox json11#83
This pull requests adds "SAX" like event driven parsing to json11. When parsing lots of objects, it allows having access to them without waiting for the whole parsing to finish. It should also limit memory usage.

This is a tentative request, it still needs work but I wanted to know if you would be open to such a feature and how you would envision it. I still need to

- write tests,
- avoid keeping all data in memory.

Also I'm not an expert in C++ so do not hesitate to point me to the problems in my code.

